### PR TITLE
Remove the distribute asset parameter on settlement

### DIFF
--- a/src/HookCoveredCallImplV1.sol
+++ b/src/HookCoveredCallImplV1.sol
@@ -520,10 +520,7 @@ contract HookCoveredCallImplV1 is
   // ----- END OF OPTION FUNCTIONS ---------//
 
   /// @dev See {IHookCoveredCall-settleOption}.
-  function settleOption(uint256 optionId, bool returnNft)
-    external
-    nonReentrant
-  {
+  function settleOption(uint256 optionId) external nonReentrant {
     CallOption storage call = optionParams[optionId];
     require(
       call.highBidder != address(0),
@@ -551,12 +548,8 @@ contract HookCoveredCallImplV1 is
       _safeTransferETHWithFallback(call.writer, call.strike);
     }
 
-    // return send option holder their earnings
+    // send option holder their earnings
     _safeTransferETHWithFallback(optionOwner, spread);
-
-    if (returnNft) {
-      IHookVault(call.vaultAddress).withdrawalAsset(call.assetId);
-    }
 
     emit CallSettled(optionId);
   }

--- a/src/HookERC721MultiVaultImplV1.sol
+++ b/src/HookERC721MultiVaultImplV1.sol
@@ -114,6 +114,10 @@ contract HookERC721MultiVaultImplV1 is
       !hasActiveEntitlement(assetId),
       "withdrawalAsset -- the asset cannot be withdrawn with an active entitlement"
     );
+    require(
+      assets[assetId].beneficialOwner == msg.sender,
+      "withdrawalAsset -- only the beneficial owner can withdrawal an asset"
+    );
 
     _nftContract.safeTransferFrom(
       address(this),

--- a/src/interfaces/IHookCoveredCall.sol
+++ b/src/interfaces/IHookCoveredCall.sol
@@ -164,8 +164,7 @@ interface IHookCoveredCall is IERC721Metadata {
   /// are subtracted from the distribution amounts.
   ///
   /// @param optionId of the option to settle.
-  /// @param returnNft true if token should be withdrawn from vault, false to leave token in the vault.
-  function settleOption(uint256 optionId, bool returnNft) external;
+  function settleOption(uint256 optionId) external;
 
   /// @notice Allows anyone to burn the instrument NFT for an expired option.
   /// @param optionId of the option to burn.

--- a/src/test/HookCoveredCallBiddingRevertTests.t.sol
+++ b/src/test/HookCoveredCallBiddingRevertTests.t.sol
@@ -96,16 +96,12 @@ contract HookCoveredCallBiddingRevertTests is HookProtocolTest {
     // settle the auction
     // assertTrue(token.ownerOf(underlyingTokenId) == address(calls), "call contract should own the token");
     vm.warp(expiration + 3 seconds);
-    calls.settleOption(optionId, true);
+    calls.settleOption(optionId);
 
     // verify the balances are correct
     uint256 writerEndBalance = writer.balance;
     uint256 buyerEndBalance = buyer.balance;
 
-    assertTrue(
-      token.ownerOf(underlyingTokenId) == bidder2,
-      "the high bidder should own the nft"
-    );
     assertTrue(
       writerEndBalance - writerStartBalance == 1000,
       "the writer gets the strike price"

--- a/src/test/HookCoveredCallIntegrationTest.t.sol
+++ b/src/test/HookCoveredCallIntegrationTest.t.sol
@@ -163,16 +163,12 @@ contract HookCoveredCallIntegrationTest is HookProtocolTest {
     // settle the auction
     // assertTrue(token.ownerOf(underlyingTokenId) == address(calls), "call contract should own the token");
     vm.warp(expiration + 3 seconds);
-    calls.settleOption(optionId, true);
+    calls.settleOption(optionId);
 
     // verify the balances are correct
     uint256 writerEndBalance = writer.balance;
     uint256 buyerEndBalance = buyer.balance;
 
-    assertTrue(
-      token.ownerOf(underlyingTokenId) == bidder2,
-      "the high bidder should own the nft"
-    );
     assertTrue(
       writerEndBalance - writerStartBalance == 1000,
       "the writer gets the strike price"

--- a/src/test/HookCoveredCallTests.t.sol
+++ b/src/test/HookCoveredCallTests.t.sol
@@ -930,7 +930,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     uint256 writerStartBalance = writer.balance;
 
     vm.prank(writer);
-    calls.settleOption(optionTokenId, false);
+    calls.settleOption(optionTokenId);
 
     assertTrue(
       buyerStartBalance + (0.2 ether - 1000 wei) == buyer.balance,
@@ -942,7 +942,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     );
   }
 
-  function testSettleOptionReturnNft() public {
+  function testSettleOption2() public {
     uint256 buyerStartBalance = buyer.balance;
     uint256 writerStartBalance = writer.balance;
 
@@ -950,13 +950,9 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
       address(token),
       underlyingTokenId
     );
-    vm.expectCall(
-      address(vault),
-      abi.encodeWithSignature("withdrawalAsset(uint32)", 0)
-    );
 
     vm.prank(writer);
-    calls.settleOption(optionTokenId, true);
+    calls.settleOption(optionTokenId);
 
     assertTrue(
       buyerStartBalance + (0.2 ether - 1000 wei) == buyer.balance,
@@ -965,10 +961,6 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     assertTrue(
       writerStartBalance + 1000 wei == writer.balance,
       "buyer should have received the option"
-    );
-    assertTrue(
-      token.ownerOf(underlyingTokenId) == address(secondBidder),
-      "secondBidder (winner) should get the underlying asset"
     );
   }
 
@@ -992,7 +984,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     // Option expires in 3 days from current block; bidding starts in 2 days.
     vm.warp(block.timestamp + 3.1 days);
     vm.expectRevert("settle -- bid must be won by someone");
-    calls.settleOption(optionId, true);
+    calls.settleOption(optionId);
   }
 
   function testCannotSettleOptionBeforeExpiration() public {
@@ -1017,15 +1009,15 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     calls.bid{value: 0.1 ether}(optionId);
 
     vm.expectRevert("settle -- option must be expired");
-    calls.settleOption(optionId, true);
+    calls.settleOption(optionId);
   }
 
   function testCannotSettleSettledOption() public {
     vm.prank(writer);
-    calls.settleOption(optionTokenId, false);
+    calls.settleOption(optionTokenId);
 
     vm.expectRevert("settle -- the call cannot already be settled");
-    calls.settleOption(optionTokenId, true);
+    calls.settleOption(optionTokenId);
   }
 
   function testSettleOptionWhenWriterHighBidder() public {
@@ -1058,7 +1050,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     calls.bid{value: 1 wei}(optionId);
     vm.warp(block.timestamp + 1 days);
 
-    calls.settleOption(optionId, false);
+    calls.settleOption(optionId);
 
     assertTrue(
       buyerStartBalance + 1 wei == buyer.balance,
@@ -1109,7 +1101,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     vm.warp(block.timestamp + 1 days);
 
     vm.prank(writer);
-    calls.settleOption(optionId, false);
+    calls.settleOption(optionId);
 
     assertTrue(
       buyerStartBalance + 1000 wei == buyer.balance,
@@ -1161,7 +1153,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     vm.warp(block.timestamp + 1 days);
 
     vm.prank(writer);
-    calls.settleOption(optionId, false);
+    calls.settleOption(optionId);
 
     assertTrue(
       buyerStartBalance + 2 wei == buyer.balance,
@@ -1216,7 +1208,7 @@ contract HookCoveredCallSettleTests is HookProtocolTest {
     vm.warp(block.timestamp + 1 days);
 
     vm.prank(writer);
-    calls.settleOption(optionId, false);
+    calls.settleOption(optionId);
 
     assertTrue(
       buyerStartBalance + 3 wei == buyer.balance,
@@ -1286,7 +1278,7 @@ contract HookCoveredCallReclaimTests is HookProtocolTest {
     setUpOptionBids();
 
     vm.startPrank(writer);
-    calls.settleOption(optionTokenId, false);
+    calls.settleOption(optionTokenId);
 
     vm.expectRevert("reclaimAsset -- the option has already been settled");
     calls.reclaimAsset(optionTokenId, true);


### PR DESCRIPTION
Currently, the protocol allows anyone to trigger a withdrawal from the vault. We're concerned that this is abused, and at a minimum, it makes it more difficult to think through potential security flaws in the system.

This change restricts that to the beneficial owner only. As a result, it is no longer possible to trigger the asset to be distributed when settling the option (a separate withdrawal transaction is necessary). So, this change removes that parameter and updates the tests accordingly. 