### PR TITLE
Block out of range NFTs in the multivaults

### DIFF
--- a/src/HookERC721MultiVaultImplV1.sol
+++ b/src/HookERC721MultiVaultImplV1.sol
@@ -182,6 +182,10 @@ contract HookERC721MultiVaultImplV1 is
     uint256 tokenId,
     bytes calldata data
   ) external virtual override returns (bytes4) {
+    require(
+      tokenId <= type(uint32).max,
+      "onERC721Received -- tokenId is out of range"
+    );
     /// (1) When receiving a nft from the ERC-721 contract this vault covers, create a new entitlement entry
     /// with the sender as the beneficial owner to track the asset within the vault.
     ///


### PR DESCRIPTION
Resolves the issues raised in M-05.

Changes:
Add a require statement to the multivault onErc721Receive function that requires that the incomming tokenId is less than the uint32 max.
