### PR TITLE
fix proper asset receiver

### DIFF
--- a/src/HookERC721MultiVaultImplV1.sol
+++ b/src/HookERC721MultiVaultImplV1.sol
@@ -422,7 +422,7 @@ contract HookERC721MultiVaultImplV1 is
       receiver,
       _assetTokenId(assetId)
     );
-    emit AssetWithdrawn(assetId, msg.sender, assets[assetId].beneficialOwner);
+    emit AssetWithdrawn(assetId, receiver, assets[assetId].beneficialOwner);
   }
 
   /// @dev Validates that a specific signature is actually the entitlement

--- a/src/test/HookVaultTests.t.sol
+++ b/src/test/HookVaultTests.t.sol
@@ -656,6 +656,8 @@ contract HookVaultTestEntitlement is HookVaultTestsBase {
 }
 
 contract HookVaultTestsDistribution is HookVaultTestsBase {
+  event AssetWithdrawn(uint32, address, address);
+
   function testClearAndDistributeReturnsNFT() public {
     (address vaultAddress, uint32 tokenId) = createVaultandAsset();
 
@@ -672,6 +674,8 @@ contract HookVaultTestsDistribution is HookVaultTestsBase {
     HookERC721VaultImplV1 vaultImpl = HookERC721VaultImplV1(vaultAddress);
 
     vm.prank(mockContract);
+    vm.expectEmit(true, true, true, false);
+    emit AssetWithdrawn(0, writer, writer);
     vaultImpl.clearEntitlementAndDistribute(0, writer);
 
     assertTrue(


### PR DESCRIPTION
Resolves issue M-01 identified in the protocol audit.


Changes:
Change emit AssetWithdrawn(assetId, msg.sender, assets[assetId].beneficialOwner); To emit AssetWithdrawn(assetId, receiver, assets[assetId].beneficialOwner); in clearEntitlementAndDistribute code.

Add a test to verify that the correct event is emitted.
