### PR TITLE
Use storage for call in burn expired option

### DIFF
--- a/src/HookCoveredCallImplV1.sol
+++ b/src/HookCoveredCallImplV1.sol
@@ -633,7 +633,7 @@ contract HookCoveredCallImplV1 is
     nonReentrant
     whenNotPaused
   {
-    CallOption memory call = optionParams[optionId];
+    CallOption storage call = optionParams[optionId];
 
     require(block.timestamp > call.expiration, "bEO-option expired");
 


### PR DESCRIPTION
Fixes a bug in the call instrument contract where minting an option on the same underlying token id after calling `burnExpiredOption` causes a revert.

We used a `memory` instead of `storage` to get the call option that we update with the `settled = true`.