### PR TITLE
getPoolOrderStructHash() turned into a pure function #98

### DIFF
--- a/src/HookBidPool.sol
+++ b/src/HookBidPool.sol
@@ -508,7 +508,6 @@ contract HookBidPool is EIP712, ReentrancyGuard, AccessControl {
         _validateOptionProperties(order, optionInstrumentAddress, optionId);
         /// even if the order technically allows it, make sure this pool cannot be used for trading
         /// expired options.
-        require(expiry > block.timestamp, "Option is expired");
         require(block.timestamp + order.minOptionDuration < expiry, "Option is too close to expiry");
         require(
             order.maxOptionDuration == 0 || block.timestamp + order.maxOptionDuration > expiry,

--- a/src/lib/PoolOrders.sol
+++ b/src/lib/PoolOrders.sol
@@ -153,7 +153,7 @@ library PoolOrders {
         );
     }
 
-    function getPoolOrderStructHash(Order memory poolOrder) internal view returns (bytes32) {
+    function getPoolOrderStructHash(Order memory poolOrder) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(_hashPt1(poolOrder), _hashPt2(poolOrder)));
     }
 }


### PR DESCRIPTION
### getPoolOrderStructHash() turned into a pure function #98
getPoolOrderStructHash() encodes and hashes an order to create the structHash for EIP 712 signing:

```
function getPoolOrderStructHash(Order memory poolOrder) internal view returns (bytes32) {
    return keccak256(abi.encodePacked(_hashPt1(poolOrder), _hashPt2(poolOrder)));
}
```
Since _ORDER_TYPEHASH and _PROPERTY_TYPEHASH are constants, this function does not read from storage.
It can therefore be changed from **view to pure to save on gas.**